### PR TITLE
extend OUTER to all integer and real kinds

### DIFF
--- a/src/forlab.f90
+++ b/src/forlab.f90
@@ -1657,6 +1657,48 @@ module forlab
         module procedure ones1, ones2, ones3
     end interface ones
 
+    interface outer
+        !! outer
+        !!-----------------------------------------------------------------------
+        !! outer computes the outer product of two vectors.
+        !!
+        !! Syntax
+        !!-----------------------------------------------------------------------
+        !! A = outer(x, y)
+        !!
+        !! Description
+        !!-----------------------------------------------------------------------
+        !! A = outer(x, y) returns the outer product of vectors x and y.
+        module function outer_int8(x, y)
+            integer(int8), dimension(:,:), allocatable :: outer_int8
+            integer(int8), dimension(:), intent(in) :: x, y
+        end function
+        module function outer_int16(x, y)
+            integer(int16), dimension(:,:), allocatable :: outer_int16
+            integer(int16), dimension(:), intent(in) :: x, y
+        end function
+        module function outer_int32(x, y)
+            integer(int32), dimension(:,:), allocatable :: outer_int32
+            integer(int32), dimension(:), intent(in) :: x, y
+        end function
+        module function outer_int64(x, y)
+            integer(int64), dimension(:,:), allocatable :: outer_int64
+            integer(int64), dimension(:), intent(in) :: x, y
+        end function
+        module function outer_sp(x, y)
+            real(sp), dimension(:,:), allocatable :: outer_sp
+            real(sp), dimension(:), intent(in) :: x, y
+        end function
+        module function outer_dp(x, y)
+            real(dp), dimension(:,:), allocatable :: outer_dp
+            real(dp), dimension(:), intent(in) :: x, y
+        end function
+        module function outer_qp(x, y)
+            real(qp), dimension(:,:), allocatable :: outer_qp
+            real(qp), dimension(:), intent(in) :: x, y
+        end function
+    end interface
+
     interface prctile
         module procedure prctile0, prctile1
     end interface prctile
@@ -6678,29 +6720,6 @@ contains
         end if
         return
     end subroutine open2
-
-    ! outer
-    !-----------------------------------------------------------------------
-    ! outer computes the outer product of two vectors.
-    !
-    ! Syntax
-    !-----------------------------------------------------------------------
-    ! A = outer(x, y)
-    !
-    ! Description
-    !-----------------------------------------------------------------------
-    ! A = outer(x, y) returns the outer product of vectors x and y.
-
-    function outer(x, y) result(A)
-        real(kind=RPRE), dimension(:, :), allocatable :: A
-        real(kind=RPRE), dimension(:), intent(in) :: x, y
-        integer(kind=IPRE) :: m, n
-
-        m = size(x)
-        n = size(y)
-        A = spread(x, 2, n)*spread(y, 1, m)
-        return
-    end function outer
 
     ! pascal
     !-----------------------------------------------------------------------

--- a/src/forlab_outer.f90
+++ b/src/forlab_outer.f90
@@ -1,0 +1,77 @@
+submodule(forlab) forlab_outer
+    use forlab_kinds
+
+contains
+
+    module procedure outer_int8
+        integer :: m, n
+
+        m = size(x)
+        n = size(y)
+        allocate(outer_int8, &
+                 source=spread(x, 2, n) * spread(y, 1, m))
+
+    end procedure
+
+    module procedure outer_int16
+        integer :: m, n
+
+        m = size(x)
+        n = size(y)
+        allocate(outer_int16, &
+                 source=spread(x, 2, n) * spread(y, 1, m))
+
+    end procedure
+
+    module procedure outer_int32
+        integer :: m, n
+
+        m = size(x)
+        n = size(y)
+        allocate(outer_int32, &
+                 source=spread(x, 2, n) * spread(y, 1, m))
+
+    end procedure
+
+    module procedure outer_int64
+        integer :: m, n
+
+        m = size(x)
+        n = size(y)
+        allocate(outer_int64, &
+                 source=spread(x, 2, n) * spread(y, 1, m))
+
+    end procedure
+
+
+    module procedure outer_sp
+        integer :: m, n
+
+        m = size(x)
+        n = size(y)
+        allocate(outer_sp, &
+                 source=spread(x, 2, n) * spread(y, 1, m))
+
+    end procedure
+
+    module procedure outer_dp
+        integer :: m, n
+
+        m = size(x)
+        n = size(y)
+        allocate(outer_dp, &
+                 source=spread(x, 2, n) * spread(y, 1, m))
+
+    end procedure
+
+    module procedure outer_qp
+        integer :: m, n
+
+        m = size(x)
+        n = size(y)
+        allocate(outer_qp, &
+                 source=spread(x, 2, n) * spread(y, 1, m))
+
+    end procedure
+
+end submodule

--- a/src/fypp/forlab.fypp
+++ b/src/fypp/forlab.fypp
@@ -1015,6 +1015,32 @@ module forlab
         module procedure ones1, ones2, ones3
     end interface ones
 
+    interface outer
+        !! outer
+        !!-----------------------------------------------------------------------
+        !! outer computes the outer product of two vectors.
+        !!
+        !! Syntax
+        !!-----------------------------------------------------------------------
+        !! A = outer(x, y)
+        !!
+        !! Description
+        !!-----------------------------------------------------------------------
+        !! A = outer(x, y) returns the outer product of vectors x and y.
+        #:for k1,t1 in INT_KINDS_TYPES
+        module function outer_${k1}$(x, y)
+            ${t1}$, dimension(:,:), allocatable :: outer_${k1}$
+            ${t1}$, dimension(:), intent(in) :: x, y
+        end function
+        #:endfor
+        #:for k1,t1 in REAL_KINDS_TYPES
+        module function outer_${k1}$(x, y)
+            ${t1}$, dimension(:,:), allocatable :: outer_${k1}$
+            ${t1}$, dimension(:), intent(in) :: x, y
+        end function
+        #:endfor
+    end interface
+
     interface prctile
         module procedure prctile0, prctile1
     end interface prctile
@@ -5679,29 +5705,6 @@ contains
         end if
         return
     end subroutine open2
-
-    ! outer
-    !-----------------------------------------------------------------------
-    ! outer computes the outer product of two vectors.
-    !
-    ! Syntax
-    !-----------------------------------------------------------------------
-    ! A = outer(x, y)
-    !
-    ! Description
-    !-----------------------------------------------------------------------
-    ! A = outer(x, y) returns the outer product of vectors x and y.
-
-    function outer(x, y) result(A)
-        real(kind=RPRE), dimension(:, :), allocatable :: A
-        real(kind=RPRE), dimension(:), intent(in) :: x, y
-        integer(kind=IPRE) :: m, n
-
-        m = size(x)
-        n = size(y)
-        A = spread(x, 2, n)*spread(y, 1, m)
-        return
-    end function outer
 
     ! pascal
     !-----------------------------------------------------------------------

--- a/src/fypp/forlab_outer.fypp
+++ b/src/fypp/forlab_outer.fypp
@@ -1,0 +1,32 @@
+#:include "common.fypp"
+submodule(forlab) forlab_outer
+    use forlab_kinds
+
+contains
+
+    #:for k1,t1 in INT_KINDS_TYPES
+    module procedure outer_${k1}$
+        integer :: m, n
+
+        m = size(x)
+        n = size(y)
+        allocate(outer_${k1}$, &
+                 source=spread(x, 2, n) * spread(y, 1, m))
+
+    end procedure
+
+    #:endfor
+
+    #:for k1,t1 in REAL_KINDS_TYPES
+    module procedure outer_${k1}$
+        integer :: m, n
+
+        m = size(x)
+        n = size(y)
+        allocate(outer_${k1}$, &
+                 source=spread(x, 2, n) * spread(y, 1, m))
+
+    end procedure
+
+    #:endfor
+end submodule

--- a/test/test.f90
+++ b/test/test.f90
@@ -137,4 +137,26 @@ program main
         L=chol(a)
         call disp(L,"L=")
     end block
+
+    block
+        use forlab, only: outer, disp
+        real :: ra(3) = [1, 2, 3]
+        real :: rb(4) = [1, 2, 3, 4]
+        real, allocatable :: rX(:,:)
+        integer :: ia(3) = [1, 2, 3]
+        integer :: ib(4) = [1, 2, 3, 4]
+        integer, allocatable :: iX(:,:)
+
+        call disp("outer test")
+        call disp("outer for real")
+        rX = outer(ra, rb)
+        call disp(ra, "a=")
+        call disp(rb, "b=")
+        call disp(rX, "a .outer. b=")
+        call disp("outer for integer")
+        iX = outer(ia, ib)
+        call disp(ia, "a=")
+        call disp(ib, "b=")
+        call disp(iX, "a .outer. b=")
+    end block
 end program


### PR DESCRIPTION
The repository already has OUTER function for calculating outer product of two vectors of real type.
So I kept the original implementation and used fypp to make it support both integer and real types.