### PR TITLE
add `is_close` function.

### DIFF
--- a/doc/specs/forlab_math.md
+++ b/doc/specs/forlab_math.md
@@ -6,6 +6,66 @@ title: MATH
 
 [TOC]
 
-## `randu`
+### `is_close`
 
-## `randn`
+#### Description
+
+Returns a boolean scalar/array where two scalars/arrays are element-wise equal within a tolerance.
+
+The tolerance values are positive, typically very small numbers. The relative difference `(rtol*abs(b))` and the absolute difference `atol` are added together to compare against the absolute difference between `a` and `b`.
+
+```fortran
+!> For `real` type
+abs(a - b) <= rtol*abs(b) + atol
+!> For `complex` type
+abs(a%re - b%re) <= rtol*abs(b%re) + atol
+abs(a%im - b%im) <= rtol*abs(b%im) + atol
+```
+
+#### Syntax
+
+`bool = [[forlab_math(module):is_close(interface)]] (a, b [, rtol, atol])`
+
+#### Status
+
+Experimental.
+
+#### Class
+
+Elemental function.
+
+#### Arguments
+
+`a`: Shall be a `real/complex` scalar/array.
+This argument is `intent(in)`.
+
+`b`: Shall be a `real/complex` scalar/array.
+This argument is `intent(in)`.
+
+`rtol`: Shall be a `real` scalar.
+This argument is `intent(in)` and `optional`, which is `1.0e-5` by default.
+
+`atol`: Shall be a `real` scalar.
+This argument is `intent(in)` and `optional`, which is `1.0e-8` by default.
+
+Note: All `real/complex` arguments must have same `kind`.
+If the value of `rtol/atol` is negative (not recommended), it will be corrected to `abs(rtol/atol)` by the internal process of `is_close`.
+
+#### Result value
+
+Returns a `logical` scalar/array.
+
+#### Example
+
+```fortran
+program demo_math_is_close
+    use forlab_math, only: is_close
+    use stdlib_error, only: check
+    real :: x(2) = [1, 2]
+    print *, is_close(x,[real :: 1, 2.1])     !! [T, F]
+    print *, all(is_close(x,[real :: 1, 2.1]))!! F
+    print *, is_close(2.0, 2.1, atol=0.1)     !! T
+    call check(all(is_close(x, [2.0, 2.0])), msg="all(is_close(x, [2.0, 2.0])) failed.", warn=.true.)
+        !! all(is_close(x, [2.0, 2.0])) failed.
+end program demo_math_is_close
+```

--- a/example/math/demo_math_is_close.f90
+++ b/example/math/demo_math_is_close.f90
@@ -1,0 +1,10 @@
+program demo_math_is_close
+    use forlab_math, only: is_close
+    use stdlib_error, only: check
+    real :: x(2) = [1, 2]
+    print *, is_close(x,[real :: 1, 2.1])     !! [T, F]
+    print *, all(is_close(x,[real :: 1, 2.1]))!! F
+    print *, is_close(2.0, 2.1, atol=0.1)     !! T
+    call check(all(is_close(x, [2.0, 2.0])), msg="all(is_close(x, [2.0, 2.0])) failed.", warn=.true.)
+        !! all(is_close(x, [2.0, 2.0])) failed.
+end program demo_math_is_close

--- a/fpm.toml
+++ b/fpm.toml
@@ -76,6 +76,10 @@ main = "test_math_angle.f90"
 name = "math_degcir"
 source-dir = "test/math"
 main = "test_math_degcir.f90"
+[[test]]
+name = "math_is_close"
+source-dir = "test/math"
+main = "test_math_is_close.f90"
 
 ## [stats] tests
 [[test]]
@@ -121,3 +125,9 @@ main = "demo_linalg_zerosones.f90"
 name = "allocation"
 source-dir = "example/linalg"
 main = "demo_allocation.f90"
+
+## forlab_math demos
+[[example]]
+name = "math_is_close"
+source-dir = "example/math"
+main = "demo_math_is_close.f90"

--- a/meta-src/forlab_math.fypp
+++ b/meta-src/forlab_math.fypp
@@ -1,12 +1,14 @@
 #:include 'common.fypp'
 module forlab_math
     use stdlib_kinds, only: sp, dp, qp
+    use stdlib_optval, only: optval
     implicit none
     private
 
     public :: angle
     public :: cosd, sind,tand
     public :: acosd, asind, atand
+    public :: is_close
 
     #:set CIR_NAME=["acos","asin","atan"]
     #:for l1 in CIR_NAME
@@ -42,6 +44,21 @@ module forlab_math
         procedure :: angle_${kind}$
         #:endfor
     end interface angle
+
+    !> Version: experimental
+    !>
+    !> Determines whether the values of `a` and `b` are close.
+    !> ([Specification](../page/specs/forlab_logic.html#is_close))
+    interface is_close
+        #:set RC_KINDS_TYPES = REAL_KINDS_TYPES + CMPLX_KINDS_TYPES
+        #:for k1, t1 in RC_KINDS_TYPES
+        elemental module function is_close_${t1[0]}$${k1}$(a, b, rtol, atol) result(result)
+            ${t1}$, intent(in) :: a, b
+            real(${k1}$), intent(in), optional :: rtol, atol
+            logical :: result
+        end function is_close_${t1[0]}$${k1}$
+        #:endfor
+    end interface is_close
 
 contains
 

--- a/meta-src/forlab_math_is_close.fypp
+++ b/meta-src/forlab_math_is_close.fypp
@@ -1,0 +1,33 @@
+#:include "common.fypp"
+
+submodule(forlab_math) forlab_math_is_close
+
+contains
+
+    #! Determines whether the values of `a` and `b` are close.
+
+    #:for k1, t1 in REAL_KINDS_TYPES
+    elemental module function is_close_${t1[0]}$${k1}$(a, b, rtol, atol) result(result)
+        ${t1}$, intent(in) :: a, b
+        real(${k1}$), intent(in), optional :: rtol, atol
+        logical :: result
+
+        result = abs(a - b) <= abs(optval(rtol, 1.0e-5_${k1}$)*b) + &
+                               abs(optval(atol, 1.0e-8_${k1}$))
+
+    end function is_close_${t1[0]}$${k1}$
+    #:endfor
+
+    #:for k1, t1 in CMPLX_KINDS_TYPES
+    elemental module function is_close_${t1[0]}$${k1}$(a, b, rtol, atol) result(result)
+        ${t1}$, intent(in) :: a, b
+        real(${k1}$), intent(in), optional :: rtol, atol
+        logical :: result
+
+        result = is_close_r${k1}$(a%re, b%re, rtol, atol) .and. &
+                 is_close_r${k1}$(a%im, b%im, rtol, atol)
+
+    end function is_close_${t1[0]}$${k1}$
+    #:endfor
+
+end submodule forlab_math_is_close

--- a/src/forlab_math.f90
+++ b/src/forlab_math.f90
@@ -1,11 +1,13 @@
 module forlab_math
     use stdlib_kinds, only: sp, dp, qp
+    use stdlib_optval, only: optval
     implicit none
     private
 
     public :: angle
     public :: cosd, sind,tand
     public :: acosd, asind, atand
+    public :: is_close
 
     interface acosd
         !! degree circular functions
@@ -105,6 +107,43 @@ module forlab_math
         procedure :: angle_dp
         procedure :: angle_qp
     end interface angle
+
+    !> Version: experimental
+    !>
+    !> Determines whether the values of `a` and `b` are close.
+    !> ([Specification](../page/specs/forlab_logic.html#is_close))
+    interface is_close
+        elemental module function is_close_rsp(a, b, rtol, atol) result(result)
+            real(sp), intent(in) :: a, b
+            real(sp), intent(in), optional :: rtol, atol
+            logical :: result
+        end function is_close_rsp
+        elemental module function is_close_rdp(a, b, rtol, atol) result(result)
+            real(dp), intent(in) :: a, b
+            real(dp), intent(in), optional :: rtol, atol
+            logical :: result
+        end function is_close_rdp
+        elemental module function is_close_rqp(a, b, rtol, atol) result(result)
+            real(qp), intent(in) :: a, b
+            real(qp), intent(in), optional :: rtol, atol
+            logical :: result
+        end function is_close_rqp
+        elemental module function is_close_csp(a, b, rtol, atol) result(result)
+            complex(sp), intent(in) :: a, b
+            real(sp), intent(in), optional :: rtol, atol
+            logical :: result
+        end function is_close_csp
+        elemental module function is_close_cdp(a, b, rtol, atol) result(result)
+            complex(dp), intent(in) :: a, b
+            real(dp), intent(in), optional :: rtol, atol
+            logical :: result
+        end function is_close_cdp
+        elemental module function is_close_cqp(a, b, rtol, atol) result(result)
+            complex(qp), intent(in) :: a, b
+            real(qp), intent(in), optional :: rtol, atol
+            logical :: result
+        end function is_close_cqp
+    end interface is_close
 
 contains
 

--- a/src/forlab_math_is_close.f90
+++ b/src/forlab_math_is_close.f90
@@ -1,0 +1,63 @@
+
+submodule(forlab_math) forlab_math_is_close
+
+contains
+
+
+    elemental module function is_close_rsp(a, b, rtol, atol) result(result)
+        real(sp), intent(in) :: a, b
+        real(sp), intent(in), optional :: rtol, atol
+        logical :: result
+
+        result = abs(a - b) <= abs(optval(rtol, 1.0e-5_sp)*b) + &
+                               abs(optval(atol, 1.0e-8_sp))
+
+    end function is_close_rsp
+    elemental module function is_close_rdp(a, b, rtol, atol) result(result)
+        real(dp), intent(in) :: a, b
+        real(dp), intent(in), optional :: rtol, atol
+        logical :: result
+
+        result = abs(a - b) <= abs(optval(rtol, 1.0e-5_dp)*b) + &
+                               abs(optval(atol, 1.0e-8_dp))
+
+    end function is_close_rdp
+    elemental module function is_close_rqp(a, b, rtol, atol) result(result)
+        real(qp), intent(in) :: a, b
+        real(qp), intent(in), optional :: rtol, atol
+        logical :: result
+
+        result = abs(a - b) <= abs(optval(rtol, 1.0e-5_qp)*b) + &
+                               abs(optval(atol, 1.0e-8_qp))
+
+    end function is_close_rqp
+
+    elemental module function is_close_csp(a, b, rtol, atol) result(result)
+        complex(sp), intent(in) :: a, b
+        real(sp), intent(in), optional :: rtol, atol
+        logical :: result
+
+        result = is_close_rsp(a%re, b%re, rtol, atol) .and. &
+                 is_close_rsp(a%im, b%im, rtol, atol)
+
+    end function is_close_csp
+    elemental module function is_close_cdp(a, b, rtol, atol) result(result)
+        complex(dp), intent(in) :: a, b
+        real(dp), intent(in), optional :: rtol, atol
+        logical :: result
+
+        result = is_close_rdp(a%re, b%re, rtol, atol) .and. &
+                 is_close_rdp(a%im, b%im, rtol, atol)
+
+    end function is_close_cdp
+    elemental module function is_close_cqp(a, b, rtol, atol) result(result)
+        complex(qp), intent(in) :: a, b
+        real(qp), intent(in), optional :: rtol, atol
+        logical :: result
+
+        result = is_close_rqp(a%re, b%re, rtol, atol) .and. &
+                 is_close_rqp(a%im, b%im, rtol, atol)
+
+    end function is_close_cqp
+
+end submodule forlab_math_is_close

--- a/test/math/test_math_is_close.f90
+++ b/test/math/test_math_is_close.f90
@@ -1,0 +1,40 @@
+program test_math_is_close
+
+    call test_math_is_close_real
+    call test_math_is_close_complex
+    print *, "All tests in `test_math_is_close` passed."
+
+contains
+
+    subroutine test_math_is_close_real
+        use forlab_math, only: is_close
+        use stdlib_error, only: check
+
+        call check(is_close(2.5, 2.5, rtol=1.0e-5), msg="is_close(2.5, 2.5, rtol=1.0e-5) failed.")
+        call check(all(is_close([2.5, 3.2], [2.5, 10.0], rtol=1.0e-5)), &
+                   msg="all(is_close([2.5, 3.2], [2.5, 10.0], rtol=1.0e-5)) failed (expected).", warn=.true.)
+        call check(all(is_close(reshape([2.5, 3.2, 2.2, 1.0], [2, 2]), reshape([2.5, 3.2001, 2.25, 1.1], [2, 2]), &
+                   atol=1.0e-5, rtol=0.1)), &
+                   msg="all(is_close(reshape([2.5, 3.2, 2.2, 1.0],[2,2]), reshape([2.5, 3.2001, 2.25, 1.1],[2,2]), &
+                   &rtol=1.0e-5, atol=0.1)) failed.")
+
+    end subroutine test_math_is_close_real
+
+    subroutine test_math_is_close_complex
+        use forlab_math, only: is_close
+        use stdlib_error, only: check
+
+        call check(is_close((2.5,1.2), (2.5,1.2), rtol=1.0e-5), &
+                   msg="is_close((2.5,1.2), (2.5,1.2), rtol=1.0e-5) failed.")
+        call check(all(is_close([(2.5,1.2), (3.2,1.2)], [(2.5,1.2), (10.0,1.2)], rtol=1.0e-5)), &
+                   msg="all(is_close([(2.5,1.2), (3.2,1.2)], [(2.5,1.2), (10.0,1.2)], rtol=1.0e-5)) failed (expected).", &
+                   warn=.true.)
+        call check(all(is_close(reshape([(2.5,1.2009), (3.2,1.199999)], [1, 2]), reshape([(2.4,1.2009), (3.15,1.199999)], [1, 2]), &
+                   atol=1.0e-5, rtol=0.1)), &
+                   msg="all(is_close(reshape([(2.5,1.2009), (3.2,1.199999)], [1, 2]), &
+                   &reshape([(2.4,1.2009), (3.15,1.199999)], [1, 2]), &
+                   &rtol=1.0e-5, atol=0.1)) failed.")
+
+    end subroutine test_math_is_close_complex
+
+end program test_math_is_close


### PR DESCRIPTION
- [x] Add `is_close` for `real/complex` value tests and checks
- [x] The default value of `rtol/atol`(`numpy.isclose` by default: `rtol=1.0e-5`, `atol=1.0e-8`; `stdlib_math : is_close` is consistent with `numpy.isclose` )
![image](https://user-images.githubusercontent.com/32035096/129995601-a4939163-fc9a-444f-85cf-0a7ad930743c.png)

#### Decsription
> Determines whether the values of `a` and `b` are close.

When we are testing, `is_close` and `all_close` are very useful.

#### Notes
Later, I ~~will~~ can't add `all_close` for `stdlib` (needs `Fortran202X: dimension(..)`).
`all_close(a, b [, rtol, atol])` =:
```fortran
all(is_close(a, b [, rtol, atol]))
```

Compared to [numpy.isclose](https://numpy.org/doc/stable/reference/generated/numpy.isclose.html#numpy.isclose), I removed the `equal_nan` parameter, which simplifies the interface, and I add support for `complex` type as well.
Now API is:
```fortran
bool = [[stdlib_math(module):is_close(interface)]] (a, b [, rtol=1.0e-5, atol=1.0e-8]) !! abs(a - b) <= rtol*abs(b) + atol
```