### PR TITLE
add arange function

### DIFF
--- a/doc/specs/forlab_math.md
+++ b/doc/specs/forlab_math.md
@@ -69,3 +69,72 @@ program demo_math_is_close
         !! all(is_close(x, [2.0, 2.0])) failed.
 end program demo_math_is_close
 ```
+
+### `arange`
+
+#### Status
+
+Experimental
+
+#### Class
+
+Pure function.
+
+#### Description
+
+Creates a rank-1 `array` of the `integer/real` type with fixed-spaced values of given spacing, within a given interval.
+
+#### Syntax
+
+`result = [[forlab_math(module):arange(interface)]](start [, end, step])`
+
+#### Arguments
+
+All arguments should be the same type and kind.
+
+`start`: Shall be an `integer/real` scalar.
+This is an `intent(in)` argument.  
+The default `start` value is `1`.
+
+`end`: Shall be an `integer/real` scalar.
+This is an `intent(in)` and `optional` argument.  
+The default `end` value is the inputted `start` value.
+
+`step`: Shall be an `integer/real` scalar and large than `0`. 
+This is an `intent(in)` and `optional` argument.   
+The default `step` value is `1`.
+
+##### Warning
+If `step = 0`, the `step` argument will be corrected to `1/1.0` by the internal process of the `arange` function.   
+If `step < 0`, the `step` argument will be corrected to `abs(step)` by the internal process of the `arange` function. 
+
+#### Return value
+
+Returns a rank-1 `array` of fixed-spaced values.
+
+For `integer` type arguments, the length of the result vector is `(end - start)/step + 1`.  
+For `real` type arguments, the length of the result vector is `floor((end - start)/step) + 1`.
+
+#### Example
+
+```fortran
+program demo_math_arange
+    use forlab_math, only: arange
+
+    print *, arange(3)                 !! [1,2,3]
+    print *, arange(-1)                !! [1,0,-1]
+    print *, arange(0,2)               !! [0,1,2]
+    print *, arange(1,-1)              !! [1,0,-1]
+    print *, arange(0, 2, 2)           !! [0,2]
+
+    print *, arange(3.0)               !! [1.0,2.0,3.0]
+    print *, arange(0.0,5.0)           !! [0.0,1.0,2.0,3.0,4.0,5.0]
+    print *, arange(0.0,6.0,2.5)       !! [0.0,2.5,5.0]
+
+    print *, (1.0,1.0)*arange(3)       !! [(1.0,1.0),(2.0,2.0),[3.0,3.0]]
+
+    print *, arange(0.0,2.0,-2.0)      !! [0.0,2.0].     Not recommended: `step` argument is negative!
+    print *, arange(0.0,2.0,0.0)       !! [0.0,1.0,2.0]. Not recommended: `step` argument is zero!
+
+end program demo_math_arange
+```

--- a/example/math/demo_math_arange.f90
+++ b/example/math/demo_math_arange.f90
@@ -1,0 +1,20 @@
+program demo_math_arange
+    use forlab_math, only: arange
+    use forlab_io, only: disp
+
+    call disp(arange(3))                 !! [1,2,3]
+    call disp(arange(-1))                !! [1,0,-1]
+    call disp(arange(0,2))               !! [0,1,2]
+    call disp(arange(1,-1))              !! [1,0,-1]
+    call disp(arange(0, 2, 2))           !! [0,2]
+
+    call disp(arange(3.0))               !! [1.0,2.0,3.0]
+    call disp(arange(0.0,5.0))           !! [0.0,1.0,2.0,3.0,4.0,5.0]
+    call disp(arange(0.0,6.0,2.5))       !! [0.0,2.5,5.0]
+
+    call disp((1.0,1.0)*arange(3))       !! [(1.0,1.0),(2.0,2.0),[3.0,3.0]]
+
+    call disp(arange(0.0,2.0,-2.0))      !! [0.0,2.0].     Not recommended: `step` argument is negative!
+    call disp(arange(0.0,2.0,0.0))       !! [0.0,1.0,2.0]. Not recommended: `step` argument is zero!
+
+end program demo_math_arange

--- a/fpm.toml
+++ b/fpm.toml
@@ -10,8 +10,6 @@ keywords = ["numerical", "easy-to-use"]
 
 [build]
 auto-executables = false
-# If you want to test or run the `example` folder examples, 
-# just set to : auto-examples = true
 auto-examples = false
 auto-tests = false
 
@@ -80,6 +78,10 @@ main = "test_math_degcir.f90"
 name = "math_is_close"
 source-dir = "test/math"
 main = "test_math_is_close.f90"
+[[test]]
+name = "math_arange"
+source-dir = "test/math"
+main = "test_math_arange.f90"
 
 ## [stats] tests
 [[test]]
@@ -131,3 +133,7 @@ main = "demo_allocation.f90"
 name = "math_is_close"
 source-dir = "example/math"
 main = "demo_math_is_close.f90"
+[[example]]
+name = "math_arange"
+source-dir = "example/math"
+main = "demo_math_arange.f90"

--- a/meta-src/forlab_math.fypp
+++ b/meta-src/forlab_math.fypp
@@ -1,6 +1,6 @@
 #:include 'common.fypp'
 module forlab_math
-    use stdlib_kinds, only: sp, dp, qp
+    use stdlib_kinds, only: sp, dp, qp, int8, int16, int32, int64
     use stdlib_optval, only: optval
     implicit none
     private
@@ -8,7 +8,7 @@ module forlab_math
     public :: angle
     public :: cosd, sind,tand
     public :: acosd, asind, atand
-    public :: is_close
+    public :: is_close, arange
 
     #:set CIR_NAME=["acos","asin","atan"]
     #:for l1 in CIR_NAME
@@ -59,6 +59,22 @@ module forlab_math
         end function is_close_${t1[0]}$${k1}$
         #:endfor
     end interface is_close
+
+    !> Version: experimental
+    !>
+    !> `arange` creates a rank-1 `array` of the `integer/real` type 
+    !>  with fixed-spaced values of given spacing, within a given interval.
+    !> ([Specification](../page/specs/forlab_math.html#arange))
+    interface arange
+        #:set RI_KINDS_TYPES = REAL_KINDS_TYPES + INT_KINDS_TYPES
+        #:for k1, t1 in RI_KINDS_TYPES
+        pure module function arange_${t1[0]}$_${k1}$(start, end, step) result(result)
+            ${t1}$, intent(in) :: start
+            ${t1}$, intent(in), optional :: end, step
+            ${t1}$, allocatable :: result(:)
+        end function arange_${t1[0]}$_${k1}$
+        #:endfor
+    end interface arange
 
 contains
 

--- a/meta-src/forlab_math_arange.fypp
+++ b/meta-src/forlab_math_arange.fypp
@@ -1,0 +1,54 @@
+#:include "common.fypp"
+submodule(forlab_math) forlab_math_arange
+
+contains
+
+    #:for k1, t1 in REAL_KINDS_TYPES
+    #! `arange` creates a vector of the `${t1}$` type 
+    #!  with evenly spaced values within a given interval.
+    pure module function arange_${t1[0]}$_${k1}$(start, end, step) result(result)
+
+        ${t1}$, intent(in) :: start
+        ${t1}$, intent(in), optional :: end, step
+        ${t1}$, allocatable :: result(:)
+        
+        ${t1}$ :: start_, end_, step_
+        integer :: i
+
+        start_ = merge(start, 1.0_${k1}$, present(end))
+        end_   = optval(end, start)
+        step_  = optval(step, 1.0_${k1}$)
+        step_  = sign(merge(step_, 1.0_${k1}$, step_ /= 0.0_${k1}$), end_ - start_)
+
+        allocate(result(floor((end_ - start_)/step_) + 1))
+
+        result = [(start_ + (i - 1)*step_, i=1, size(result), 1)]
+
+    end function arange_${t1[0]}$_${k1}$
+    #:endfor
+
+    #:for k1, t1 in INT_KINDS_TYPES
+    !> `arange` creates a vector of the `${t1}$` type 
+    !>  with evenly spaced values within a given interval.
+    pure module function arange_${t1[0]}$_${k1}$(start, end, step) result(result)
+
+        ${t1}$, intent(in) :: start
+        ${t1}$, intent(in), optional :: end, step
+        ${t1}$, allocatable :: result(:)
+        
+        ${t1}$ :: start_, end_, step_
+        ${t1}$ :: i
+
+        start_ = merge(start, 1_${k1}$, present(end))
+        end_   = optval(end, start)
+        step_  = optval(step, 1_${k1}$)
+        step_  = sign(merge(step_, 1_${k1}$, step_ /= 0_${k1}$), end_ - start_)
+
+        allocate(result((end_ - start_)/step_ + 1_${k1}$))
+
+        result = [(i, i=start_, end_, step_)]
+
+    end function arange_${t1[0]}$_${k1}$
+    #:endfor
+
+end submodule forlab_math_arange

--- a/src/forlab_math.f90
+++ b/src/forlab_math.f90
@@ -1,5 +1,5 @@
 module forlab_math
-    use stdlib_kinds, only: sp, dp, qp
+    use stdlib_kinds, only: sp, dp, qp, int8, int16, int32, int64
     use stdlib_optval, only: optval
     implicit none
     private
@@ -7,7 +7,7 @@ module forlab_math
     public :: angle
     public :: cosd, sind,tand
     public :: acosd, asind, atand
-    public :: is_close
+    public :: is_close, arange
 
     interface acosd
         !! degree circular functions
@@ -144,6 +144,49 @@ module forlab_math
             logical :: result
         end function is_close_cqp
     end interface is_close
+
+    !> Version: experimental
+    !>
+    !> `arange` creates a rank-1 `array` of the `integer/real` type 
+    !>  with fixed-spaced values of given spacing, within a given interval.
+    !> ([Specification](../page/specs/forlab_math.html#arange))
+    interface arange
+        pure module function arange_r_sp(start, end, step) result(result)
+            real(sp), intent(in) :: start
+            real(sp), intent(in), optional :: end, step
+            real(sp), allocatable :: result(:)
+        end function arange_r_sp
+        pure module function arange_r_dp(start, end, step) result(result)
+            real(dp), intent(in) :: start
+            real(dp), intent(in), optional :: end, step
+            real(dp), allocatable :: result(:)
+        end function arange_r_dp
+        pure module function arange_r_qp(start, end, step) result(result)
+            real(qp), intent(in) :: start
+            real(qp), intent(in), optional :: end, step
+            real(qp), allocatable :: result(:)
+        end function arange_r_qp
+        pure module function arange_i_int8(start, end, step) result(result)
+            integer(int8), intent(in) :: start
+            integer(int8), intent(in), optional :: end, step
+            integer(int8), allocatable :: result(:)
+        end function arange_i_int8
+        pure module function arange_i_int16(start, end, step) result(result)
+            integer(int16), intent(in) :: start
+            integer(int16), intent(in), optional :: end, step
+            integer(int16), allocatable :: result(:)
+        end function arange_i_int16
+        pure module function arange_i_int32(start, end, step) result(result)
+            integer(int32), intent(in) :: start
+            integer(int32), intent(in), optional :: end, step
+            integer(int32), allocatable :: result(:)
+        end function arange_i_int32
+        pure module function arange_i_int64(start, end, step) result(result)
+            integer(int64), intent(in) :: start
+            integer(int64), intent(in), optional :: end, step
+            integer(int64), allocatable :: result(:)
+        end function arange_i_int64
+    end interface arange
 
 contains
 

--- a/src/forlab_math_arange.f90
+++ b/src/forlab_math_arange.f90
@@ -1,0 +1,148 @@
+submodule(forlab_math) forlab_math_arange
+
+contains
+
+    pure module function arange_r_sp(start, end, step) result(result)
+
+        real(sp), intent(in) :: start
+        real(sp), intent(in), optional :: end, step
+        real(sp), allocatable :: result(:)
+        
+        real(sp) :: start_, end_, step_
+        integer :: i
+
+        start_ = merge(start, 1.0_sp, present(end))
+        end_   = optval(end, start)
+        step_  = optval(step, 1.0_sp)
+        step_  = sign(merge(step_, 1.0_sp, step_ /= 0.0_sp), end_ - start_)
+
+        allocate(result(floor((end_ - start_)/step_) + 1))
+
+        result = [(start_ + (i - 1)*step_, i=1, size(result), 1)]
+
+    end function arange_r_sp
+    pure module function arange_r_dp(start, end, step) result(result)
+
+        real(dp), intent(in) :: start
+        real(dp), intent(in), optional :: end, step
+        real(dp), allocatable :: result(:)
+        
+        real(dp) :: start_, end_, step_
+        integer :: i
+
+        start_ = merge(start, 1.0_dp, present(end))
+        end_   = optval(end, start)
+        step_  = optval(step, 1.0_dp)
+        step_  = sign(merge(step_, 1.0_dp, step_ /= 0.0_dp), end_ - start_)
+
+        allocate(result(floor((end_ - start_)/step_) + 1))
+
+        result = [(start_ + (i - 1)*step_, i=1, size(result), 1)]
+
+    end function arange_r_dp
+    pure module function arange_r_qp(start, end, step) result(result)
+
+        real(qp), intent(in) :: start
+        real(qp), intent(in), optional :: end, step
+        real(qp), allocatable :: result(:)
+        
+        real(qp) :: start_, end_, step_
+        integer :: i
+
+        start_ = merge(start, 1.0_qp, present(end))
+        end_   = optval(end, start)
+        step_  = optval(step, 1.0_qp)
+        step_  = sign(merge(step_, 1.0_qp, step_ /= 0.0_qp), end_ - start_)
+
+        allocate(result(floor((end_ - start_)/step_) + 1))
+
+        result = [(start_ + (i - 1)*step_, i=1, size(result), 1)]
+
+    end function arange_r_qp
+
+    !> `arange` creates a vector of the `integer(int8)` type 
+    !>  with evenly spaced values within a given interval.
+    pure module function arange_i_int8(start, end, step) result(result)
+
+        integer(int8), intent(in) :: start
+        integer(int8), intent(in), optional :: end, step
+        integer(int8), allocatable :: result(:)
+        
+        integer(int8) :: start_, end_, step_
+        integer(int8) :: i
+
+        start_ = merge(start, 1_int8, present(end))
+        end_   = optval(end, start)
+        step_  = optval(step, 1_int8)
+        step_  = sign(merge(step_, 1_int8, step_ /= 0_int8), end_ - start_)
+
+        allocate(result((end_ - start_)/step_ + 1_int8))
+
+        result = [(i, i=start_, end_, step_)]
+
+    end function arange_i_int8
+    !> `arange` creates a vector of the `integer(int16)` type 
+    !>  with evenly spaced values within a given interval.
+    pure module function arange_i_int16(start, end, step) result(result)
+
+        integer(int16), intent(in) :: start
+        integer(int16), intent(in), optional :: end, step
+        integer(int16), allocatable :: result(:)
+        
+        integer(int16) :: start_, end_, step_
+        integer(int16) :: i
+
+        start_ = merge(start, 1_int16, present(end))
+        end_   = optval(end, start)
+        step_  = optval(step, 1_int16)
+        step_  = sign(merge(step_, 1_int16, step_ /= 0_int16), end_ - start_)
+
+        allocate(result((end_ - start_)/step_ + 1_int16))
+
+        result = [(i, i=start_, end_, step_)]
+
+    end function arange_i_int16
+    !> `arange` creates a vector of the `integer(int32)` type 
+    !>  with evenly spaced values within a given interval.
+    pure module function arange_i_int32(start, end, step) result(result)
+
+        integer(int32), intent(in) :: start
+        integer(int32), intent(in), optional :: end, step
+        integer(int32), allocatable :: result(:)
+        
+        integer(int32) :: start_, end_, step_
+        integer(int32) :: i
+
+        start_ = merge(start, 1_int32, present(end))
+        end_   = optval(end, start)
+        step_  = optval(step, 1_int32)
+        step_  = sign(merge(step_, 1_int32, step_ /= 0_int32), end_ - start_)
+
+        allocate(result((end_ - start_)/step_ + 1_int32))
+
+        result = [(i, i=start_, end_, step_)]
+
+    end function arange_i_int32
+    !> `arange` creates a vector of the `integer(int64)` type 
+    !>  with evenly spaced values within a given interval.
+    pure module function arange_i_int64(start, end, step) result(result)
+
+        integer(int64), intent(in) :: start
+        integer(int64), intent(in), optional :: end, step
+        integer(int64), allocatable :: result(:)
+        
+        integer(int64) :: start_, end_, step_
+        integer(int64) :: i
+
+        start_ = merge(start, 1_int64, present(end))
+        end_   = optval(end, start)
+        step_  = optval(step, 1_int64)
+        step_  = sign(merge(step_, 1_int64, step_ /= 0_int64), end_ - start_)
+
+        allocate(result((end_ - start_)/step_ + 1_int64))
+
+        result = [(i, i=start_, end_, step_)]
+
+    end function arange_i_int64
+
+end submodule forlab_math_arange

--- a/test/math/test_math_arange.f90
+++ b/test/math/test_math_arange.f90
@@ -1,0 +1,52 @@
+!> SPDX-Identifier: MIT
+module test_math_arange
+
+    use stdlib_error, only: check
+    use forlab_math, only: arange
+
+    logical, private :: warn = .false.
+
+contains
+
+    subroutine test_math_arange_real
+        !> Normal
+        call check(all(arange(3.0) == [1.0, 2.0, 3.0]),        msg="all(arange(3.0) == [1.0,2.0,3.0]) failed.",           warn=warn)
+        call check(all(arange(-1.0) == [1.0, 0.0, -1.0]),      msg="all(arange(-1.0) == [1.0,0.0,-1.0]) failed.",         warn=warn)
+        call check(all(arange(0.0, 2.0) == [0.0, 1.0, 2.0]),   msg="all(arange(0.0,2.0) == [0.0,1.0,2.0]) failed.",       warn=warn)
+        call check(all(arange(1.0, -1.0) == [1.0, 0.0, -1.0]), msg="all(arange(1.0,-1.0) == [1.0,0.0,-1.0]) failed.",     warn=warn)
+        call check(all(arange(1.0, 1.0) == [1.0]),             msg="all(arange(1.0,1.0) == [1.0]) failed.",               warn=warn)
+        call check(all(arange(0.0, 2.0, 2.0) == [0.0, 2.0]),   msg="all(arange(0.0,2.0,2.0) == [0.0,2.0]) failed.",       warn=warn)
+        call check(all(arange(1.0, -1.0, 2.0) == [1.0, -1.0]), msg="all(arange(1.0,-1.0,2.0) == [1.0,-1.0]) failed.",     warn=warn)
+        !> Not recommended
+        call check(all(arange(0.0, 2.0, -2.0) == [0.0, 2.0]),  msg="all(arange(0.0,2.0,-2.0) == [0.0,2.0]) failed.",      warn=warn)
+        call check(all(arange(1.0, -1.0, -2.0) == [1.0, -1.0]),msg="all(arange(1.0,-1.0,-2.0) == [1.0,-1.0]) failed.",    warn=warn)
+        call check(all(arange(0.0, 2.0, 0.0) == [0.0,1.0,2.0]),msg="all(arange(0.0, 2.0, 0.0) == [0.0,1.0,2.0]) failed.", warn=warn)
+    end subroutine test_math_arange_real
+
+    subroutine test_math_arange_integer
+        !> Normal
+        call check(all(arange(3) == [1, 2, 3]),        msg="all(arange(3) == [1,2,3]) failed.",       warn=warn)
+        call check(all(arange(-1) == [1, 0, -1]),      msg="all(arange(-1) == [1,0,-1]) failed.",     warn=warn)
+        call check(all(arange(0, 2) == [0, 1, 2]),     msg="all(arange(0,2) == [0,1,2]) failed.",     warn=warn)
+        call check(all(arange(1, -1) == [1, 0, -1]),   msg="all(arange(1,-1) == [1,0,-1]) failed.",   warn=warn)
+        call check(all(arange(1, 1) == [1]),           msg="all(arange(1,1) == [1]) failed.",         warn=warn)
+        call check(all(arange(0, 2, 2) == [0, 2]),     msg="all(arange(0,2,2) == [0,2]) failed.",     warn=warn)
+        call check(all(arange(1, -1, 2) == [1, -1]),   msg="all(arange(1,-1,2) == [1,-1]) failed.",   warn=warn)
+        !> Not recommended
+        call check(all(arange(0, 2, -2) == [0, 2]),    msg="all(arange(0,2,-2) == [0,2]) failed.",    warn=warn)
+        call check(all(arange(1, -1, -2) == [1, -1]),  msg="all(arange(1,-1,-2) == [1,-1]) failed.",  warn=warn)
+        call check(all(arange(0, 2, 0) == [0,1,2]),    msg="all(arange(0, 2, 0) == [0,1,2]) failed.", warn=warn)
+    end subroutine test_math_arange_integer
+
+end module test_math_arange
+
+program tester
+
+    use test_math_arange
+
+    call test_math_arange_real
+    call test_math_arange_integer
+    
+    print *, "All tests in `test_math_arange` passed."
+
+end program tester


### PR DESCRIPTION
- [x] add `arange` function. (same as `[[stdlib_math(module):arange(interface)]]`)

#### Description
Creates a rank-1 `array` of the `integer/real` type with fixed-spaced values of given spacing, within a given interval.

#### Notes
Because the latest `stdlib` does not support as an FPM dependency package, but the informal `forlab` can, so I put the arange function I wrote in the `forlab` (as a backup).

Also, I need to help `stdlib` build its fpm branche, such as https://github.com/fortran-lang/stdlib/pull/437.